### PR TITLE
Fix Moodle data directory permissions

### DIFF
--- a/3.x/docker-entrypoint.sh
+++ b/3.x/docker-entrypoint.sh
@@ -53,6 +53,14 @@ if [[ "$1" == apache2* ]]; then
     fi
   done
 
+  : "${MOODLE_DATA_ROOT:=/var/www/moodledata}"
+  # Bind mounts can replace the image directory with a root-owned host path.
+  if [ "$(id -u)" = '0' ]; then
+    mkdir -p "$MOODLE_DATA_ROOT"
+    chown www-data:www-data "$MOODLE_DATA_ROOT"
+    chmod 0750 "$MOODLE_DATA_ROOT"
+  fi
+
   # linking backwards-compatibility
   if [ -n "${!MYSQL_ENV_MYSQL_*}" ]; then
     haveConfig=1
@@ -76,9 +84,6 @@ if [[ "$1" == apache2* ]]; then
     : "${MOODLE_DB_PASSWORD:=}"
     : "${MOODLE_DB_PREFIX:=mdl_}"
     : "${MOODLE_WWW_ROOT:=}"
-    : "${MOODLE_DATA_ROOT:=/var/www/moodledata}"
-
-
     if [ ! -e "config.php" ]; then
       mv config-dist.php config.php
       chown www-data:www-data config.php


### PR DESCRIPTION
## Summary

- create the configured Moodle data directory during container startup
- assign it to the Apache `www-data` user with restrictive write permissions
- avoid a recursive ownership change on every restart

This handles bind-mounted directories that otherwise remain owned by root and cannot be written by the Moodle installer.

## Testing

- `bash -n 3.x/docker-entrypoint.sh`
- `git diff --check`
- Docker image test not run because the local Docker daemon is unavailable

Fixes #2