### PR TITLE
Keep README and Docker Hub overview in sync

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
     branches: [master]
+    paths-ignore:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
   workflow_dispatch:
   schedule:
     - cron: "17 3 * * 0"

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -1,0 +1,28 @@
+name: Docker Hub description
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - README.md
+      - .github/workflows/dockerhub-description.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Update Docker Hub overview
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: aesr/moodle
+          short-description: Versioned multi-architecture Moodle images for development and self-hosting.
+          readme-filepath: ./README.md

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
 # Moodle Docker
 
+[![Latest release](https://img.shields.io/github/v/release/42ae/moodle-docker?label=release)](https://github.com/42ae/moodle-docker/releases/latest)
 [![Docker images](https://github.com/42ae/moodle-docker/actions/workflows/docker.yml/badge.svg)](https://github.com/42ae/moodle-docker/actions/workflows/docker.yml)
+[![Docker pulls](https://img.shields.io/docker/pulls/aesr/moodle)](https://hub.docker.com/r/aesr/moodle)
 
-![Moodle](assets/moodle-logo.png "Moodle logo")
+![Moodle](https://raw.githubusercontent.com/42ae/moodle-docker/master/assets/moodle-logo.png "Moodle logo")
 
 Versioned, multi-architecture Moodle images for local development and self-hosted deployments. Images are published to [GitHub Container Registry](https://github.com/42ae/moodle-docker/pkgs/container/moodle) and [Docker Hub](https://hub.docker.com/r/aesr/moodle).
 
 > [!CAUTION]
-> The `latest` tag now tracks Moodle 5.2, not the historical Moodle 3.x image. Existing installations must pin `3.11` before pulling, or follow the [staged upgrade guide](UPGRADING.md). Never upgrade a production database without a tested backup and plugin-compatibility review.
+> The `latest` tag now tracks Moodle 5.2, not the historical Moodle 3.x image. Existing installations must pin `3.11` before pulling, or follow the [staged upgrade guide](https://github.com/42ae/moodle-docker/blob/master/UPGRADING.md). Never upgrade a production database without a tested backup and plugin-compatibility review.
 
 ## Available versions
 
@@ -47,7 +49,7 @@ docker compose pull
 docker compose up -d
 ```
 
-Supported choices include `3.11`, `4.1`, `4.5`, and `5.2`. Changing the value on an existing installation is an upgrade, not a downgrade or a fresh selection; follow [UPGRADING.md](UPGRADING.md).
+Supported choices include `3.11`, `4.1`, `4.5`, and `5.2`. Changing the value on an existing installation is an upgrade, not a downgrade or a fresh selection; follow the [upgrade guide](https://github.com/42ae/moodle-docker/blob/master/UPGRADING.md).
 
 GitHub Container Registry is the default. To use Docker Hub instead:
 
@@ -84,7 +86,7 @@ Only database data and `moodledata` are persisted by the supplied Compose file:
 - `db_data` stores MySQL files.
 - `moodle_data` stores uploads, caches, and generated application data.
 
-Moodle core remains inside the immutable image. Do not mount a volume over `/var/www/html`; doing so hides the versioned code and makes upgrades difficult to reproduce. Back up both the database and `moodledata`, and test restores regularly. See [UPGRADING.md](UPGRADING.md) for example backup and upgrade commands.
+Moodle core remains inside the immutable image. Do not mount a volume over `/var/www/html`; doing so hides the versioned code and makes upgrades difficult to reproduce. Back up both the database and `moodledata`, and test restores regularly. See the [upgrade guide](https://github.com/42ae/moodle-docker/blob/master/UPGRADING.md) for example backup and upgrade commands.
 
 ## Plugins, themes, and extra PHP extensions
 
@@ -117,7 +119,7 @@ docker compose exec --user www-data moodle php admin/cli/cron.php
 
 ## Build locally
 
-Version metadata and verified upstream SHA-256 values live in [`versions.json`](versions.json). For example:
+Version metadata and verified upstream SHA-256 values live in [`versions.json`](https://github.com/42ae/moodle-docker/blob/master/versions.json). For example:
 
 ```console
 docker build \


### PR DESCRIPTION
## Summary

- add release and Docker pull badges to the README
- make README links and the Moodle logo render correctly on Docker Hub
- automatically sync `README.md` to the `aesr/moodle` Docker Hub overview
- avoid rebuilding all Moodle images for future documentation-only pushes

## Validation

- `git diff --check`
- README remains below Docker Hub’s 25 KB overview limit
- GitHub Actions workflow YAML parses successfully
- third-party action is pinned to the current v5 commit SHA